### PR TITLE
# Add an atlas outline opacity slider

### DIFF
--- a/app.js
+++ b/app.js
@@ -674,7 +674,7 @@ function getDescendantIds(structureId) {
 }
 
 function applyDimmed(mesh) {
-  if (backgroundAlpha === 0) {
+  if (!mesh.userData.isRoot || backgroundAlpha === 0) {
     mesh.visible = false;
   } else {
     const orig = mesh.userData.originalMaterial;
@@ -684,9 +684,12 @@ function applyDimmed(mesh) {
       mat.opacity = backgroundAlpha;
       mat.transparent = true;
       mat.depthWrite = false;
+      mat.depthTest = false;
       mat.needsUpdate = true;
       mesh.material = mat;
     }
+    mesh.renderOrder = -1;
+    mesh.scale.setScalar(1);
     mesh.visible = true;
   }
   mesh.userData.isDimmed = true;
@@ -784,6 +787,8 @@ function showRootOnly() {
       mat.depthWrite = regionAlpha >= 1;
       mat.needsUpdate = true;
       mesh.material = mat;
+      mesh.scale.setScalar(1);
+      mesh.renderOrder = 0;
       mesh.visible = true;
       mesh.userData.isDimmed = false;
     } else {

--- a/app.js
+++ b/app.js
@@ -106,6 +106,7 @@ let selectedDandiset = null;
 let dandisetElectrodes = {};  // cache: dandiset_id -> {asset_id: [[x,y,z], ...]}
 let electrodePoints = null;   // THREE.Points object
 let regionAlpha = 1;          // global opacity multiplier for brain meshes
+let backgroundAlpha = 0;         // opacity for dimmed background meshes (0 = hidden, updated when slider shown)
 let dandisetRegionFilter = null; // structure_id when filtering subjects by region within a dandiset
 let dandisetSubjectCounts = null; // { directSubjects, totalSubjects } when a dandiset is selected
 let hiddenRegionIds = new Set();  // regions toggled off by user in dandiset/subject view
@@ -121,6 +122,8 @@ async function loadAtlas(atlasKey) {
 
   // Clear existing state
   clearElectrodePoints();
+  document.getElementById('background-control-row').classList.add('hidden');
+  backgroundAlpha = 0;
   selectedId = null;
   hoveredId = null;
   selectedDandiset = null;
@@ -189,9 +192,16 @@ async function loadAtlas(atlasKey) {
 
   hideLoading();
 
-  // Select root
+  // Show only root mesh at init (no isolation, no context slider)
   const rootNode = structureGraph[0];
-  if (rootNode) selectRegion(rootNode.id, { expandTree: true, pushState: false });
+  if (rootNode) {
+    showRootOnly();
+    selectedId = rootNode.id;
+    expandToNode(rootNode.id);
+    const el = document.querySelector(`.tree-node-content[data-id="${rootNode.id}"]`);
+    if (el) el.classList.add('selected');
+    updateRegionPanel(rootNode.id);
+  }
 
   // Fetch dandiset titles in background
   fetchDandisetTitles();
@@ -271,8 +281,16 @@ async function init() {
 
   // Restore view from URL hash, or default to root selection
   if (!location.hash.slice(1)) {
+    // Show only root mesh at init (no isolation, no context slider)
     const rootNode = structureGraph[0];
-    if (rootNode) selectRegion(rootNode.id, { expandTree: true, pushState: false });
+    if (rootNode) {
+      showRootOnly();
+      selectedId = rootNode.id;
+      expandToNode(rootNode.id);
+      const el = document.querySelector(`.tree-node-content[data-id="${rootNode.id}"]`);
+      if (el) el.classList.add('selected');
+      updateRegionPanel(rootNode.id);
+    }
   } else {
     applyHashState();
   }
@@ -656,25 +674,22 @@ function getDescendantIds(structureId) {
 }
 
 function applyDimmed(mesh) {
-  if (activeAtlas.coordSystem === 'allen') {
-    // CCF: hide completely (original behavior)
+  if (backgroundAlpha === 0) {
     mesh.visible = false;
-    mesh.userData.isDimmed = true;
   } else {
-    // Macaque: neutral gray ghost for anatomical context
     const orig = mesh.userData.originalMaterial;
     if (orig) {
       const mat = orig.clone();
       mat.color.set(0x888888);
-      mat.opacity = Math.min(orig.opacity, 0.08) * regionAlpha;
+      mat.opacity = backgroundAlpha;
       mat.transparent = true;
       mat.depthWrite = false;
       mat.needsUpdate = true;
       mesh.material = mat;
     }
     mesh.visible = true;
-    mesh.userData.isDimmed = true;
   }
+  mesh.userData.isDimmed = true;
 }
 
 function restoreOriginal(mesh) {
@@ -691,16 +706,9 @@ function restoreOriginal(mesh) {
 function applyActive(mesh) {
   const orig = mesh.userData.originalMaterial;
   const mat = orig.clone();
-  if (mesh.userData.isRoot && activeAtlas.coordSystem !== 'allen') {
-    // Macaque: root mesh keeps its configured low opacity even when "active"
-    mat.opacity = orig.opacity * regionAlpha;
-    mat.transparent = true;
-    mat.depthWrite = false;
-  } else {
-    mat.opacity = regionAlpha;
-    mat.transparent = regionAlpha < 1;
-    mat.depthWrite = regionAlpha >= 1;
-  }
+  mat.opacity = regionAlpha;
+  mat.transparent = regionAlpha < 1;
+  mat.depthWrite = regionAlpha >= 1;
   mat.needsUpdate = true;
   mesh.material = mat;
   mesh.visible = true;
@@ -753,10 +761,40 @@ function applyIsolation(selectedStructureId, activeIds, fallbackId) {
   }
 }
 
-function showAllRegions() {
+function showBackgroundSlider() {
+  const row = document.getElementById('background-control-row');
+  row.classList.remove('hidden');
+  backgroundAlpha = parseFloat(document.getElementById('background-alpha').value);
   for (const mesh of Object.values(meshObjects)) {
-    restoreOriginal(mesh);
+    if (mesh.userData.isDimmed) applyDimmed(mesh);
   }
+}
+
+function showRootOnly() {
+  document.getElementById('background-control-row').classList.add('hidden');
+  backgroundAlpha = 0;
+  for (const [idStr, mesh] of Object.entries(meshObjects)) {
+    const id = parseInt(idStr);
+    if (id === meshManifest.root_id) {
+      // Root at full regionAlpha (rootOpacity is for shell mode, not init view)
+      const orig = mesh.userData.originalMaterial;
+      const mat = orig.clone();
+      mat.opacity = regionAlpha;
+      mat.transparent = regionAlpha < 1;
+      mat.depthWrite = regionAlpha >= 1;
+      mat.needsUpdate = true;
+      mesh.material = mat;
+      mesh.visible = true;
+      mesh.userData.isDimmed = false;
+    } else {
+      mesh.visible = false;
+      mesh.userData.isDimmed = false;
+    }
+  }
+}
+
+function showAllRegions() {
+  showRootOnly();
 }
 
 function computeDandisetSubjectCounts(dandisetId) {
@@ -869,8 +907,9 @@ async function selectDandiset(dandisetId, { pushState = true } = {}) {
     }
   }
 
+  // Root is always context (dimmed) when a dandiset is selected
+  activeSet.delete(meshManifest.root_id);
   // Apply isolation: show active regions, dim/hide everything else
-  if (activeAtlas.coordSystem === 'allen') activeSet.delete(meshManifest.root_id);
   for (const [idStr, mesh] of Object.entries(meshObjects)) {
     const id = parseInt(idStr);
     if (activeSet.has(id)) {
@@ -885,6 +924,8 @@ async function selectDandiset(dandisetId, { pushState = true } = {}) {
       applyDimmed(mesh);
     }
   }
+
+  showBackgroundSlider();
 
   // Update right panel to show dandiset info
   updateDandisetPanel(dandisetId, structureIds);
@@ -1476,7 +1517,8 @@ async function isolateStructureIds(structureIds) {
     }
   }
 
-  if (activeAtlas.coordSystem === 'allen') activeSet.delete(meshManifest.root_id);
+  // Root is always context (dimmed) when structures are isolated
+  activeSet.delete(meshManifest.root_id);
   for (const [idStr, mesh] of Object.entries(meshObjects)) {
     const id = parseInt(idStr);
     if (activeSet.has(id)) {
@@ -1655,6 +1697,7 @@ function selectRegion(structureId, { expandTree = true, pushState = true } = {})
 
   // Isolate this region in the 3D view, then highlight
   isolateRegion(structureId);
+  showBackgroundSlider();
   highlightMesh(structureId);
 
   // Update tree selection
@@ -2135,6 +2178,23 @@ document.getElementById('electrode-alpha').addEventListener('input', (e) => {
   }
 });
 
+document.getElementById('background-alpha').addEventListener('input', (e) => {
+  backgroundAlpha = parseFloat(e.target.value);
+  for (const mesh of Object.values(meshObjects)) {
+    if (!mesh.userData.isDimmed) continue;
+    if (backgroundAlpha === 0) {
+      mesh.visible = false;
+    } else {
+      mesh.visible = true;
+      mesh.material.color.set(0x888888);
+      mesh.material.opacity = backgroundAlpha;
+      mesh.material.transparent = true;
+      mesh.material.depthWrite = false;
+      mesh.material.needsUpdate = true;
+    }
+  }
+});
+
 document.getElementById('region-alpha').addEventListener('input', (e) => {
   regionAlpha = parseFloat(e.target.value);
   for (const mesh of Object.values(meshObjects)) {
@@ -2196,6 +2256,8 @@ async function applyHashState() {
       dandisetSubjectCounts = null;
       hiddenRegionIds = new Set();
       document.getElementById('region-toggles-overlay').classList.add('hidden');
+      document.getElementById('background-control-row').classList.add('hidden');
+      backgroundAlpha = 0;
       clearElectrodePoints();
       const prevEl = document.querySelector('.tree-node-content.selected');
       if (prevEl) prevEl.classList.remove('selected');

--- a/app.js
+++ b/app.js
@@ -106,7 +106,7 @@ let selectedDandiset = null;
 let dandisetElectrodes = {};  // cache: dandiset_id -> {asset_id: [[x,y,z], ...]}
 let electrodePoints = null;   // THREE.Points object
 let regionAlpha = 1;          // global opacity multiplier for brain meshes
-let backgroundAlpha = 0;         // opacity for dimmed background meshes (0 = hidden, updated when slider shown)
+let outlineAlpha = 0;         // opacity for atlas outline mesh (0 = hidden, updated when slider shown)
 let dandisetRegionFilter = null; // structure_id when filtering subjects by region within a dandiset
 let dandisetSubjectCounts = null; // { directSubjects, totalSubjects } when a dandiset is selected
 let hiddenRegionIds = new Set();  // regions toggled off by user in dandiset/subject view
@@ -122,8 +122,8 @@ async function loadAtlas(atlasKey) {
 
   // Clear existing state
   clearElectrodePoints();
-  document.getElementById('background-control-row').classList.add('hidden');
-  backgroundAlpha = 0;
+  document.getElementById('outline-control-row').classList.add('hidden');
+  outlineAlpha = 0;
   selectedId = null;
   hoveredId = null;
   selectedDandiset = null;
@@ -674,14 +674,14 @@ function getDescendantIds(structureId) {
 }
 
 function applyDimmed(mesh) {
-  if (!mesh.userData.isRoot || backgroundAlpha === 0) {
+  if (!mesh.userData.isRoot || outlineAlpha === 0) {
     mesh.visible = false;
   } else {
     const orig = mesh.userData.originalMaterial;
     if (orig) {
       const mat = orig.clone();
       mat.color.set(0x888888);
-      mat.opacity = backgroundAlpha;
+      mat.opacity = outlineAlpha;
       mat.transparent = true;
       mat.depthWrite = false;
       mat.depthTest = false;
@@ -764,18 +764,18 @@ function applyIsolation(selectedStructureId, activeIds, fallbackId) {
   }
 }
 
-function showBackgroundSlider() {
-  const row = document.getElementById('background-control-row');
+function showOutlineSlider() {
+  const row = document.getElementById('outline-control-row');
   row.classList.remove('hidden');
-  backgroundAlpha = parseFloat(document.getElementById('background-alpha').value);
+  outlineAlpha = parseFloat(document.getElementById('outline-alpha').value);
   for (const mesh of Object.values(meshObjects)) {
     if (mesh.userData.isDimmed) applyDimmed(mesh);
   }
 }
 
 function showRootOnly() {
-  document.getElementById('background-control-row').classList.add('hidden');
-  backgroundAlpha = 0;
+  document.getElementById('outline-control-row').classList.add('hidden');
+  outlineAlpha = 0;
   for (const [idStr, mesh] of Object.entries(meshObjects)) {
     const id = parseInt(idStr);
     if (id === meshManifest.root_id) {
@@ -930,7 +930,7 @@ async function selectDandiset(dandisetId, { pushState = true } = {}) {
     }
   }
 
-  showBackgroundSlider();
+  showOutlineSlider();
 
   // Update right panel to show dandiset info
   updateDandisetPanel(dandisetId, structureIds);
@@ -1702,7 +1702,7 @@ function selectRegion(structureId, { expandTree = true, pushState = true } = {})
 
   // Isolate this region in the 3D view, then highlight
   isolateRegion(structureId);
-  showBackgroundSlider();
+  showOutlineSlider();
   highlightMesh(structureId);
 
   // Update tree selection
@@ -2183,16 +2183,16 @@ document.getElementById('electrode-alpha').addEventListener('input', (e) => {
   }
 });
 
-document.getElementById('background-alpha').addEventListener('input', (e) => {
-  backgroundAlpha = parseFloat(e.target.value);
+document.getElementById('outline-alpha').addEventListener('input', (e) => {
+  outlineAlpha = parseFloat(e.target.value);
   for (const mesh of Object.values(meshObjects)) {
     if (!mesh.userData.isDimmed) continue;
-    if (backgroundAlpha === 0) {
+    if (outlineAlpha === 0) {
       mesh.visible = false;
     } else {
       mesh.visible = true;
       mesh.material.color.set(0x888888);
-      mesh.material.opacity = backgroundAlpha;
+      mesh.material.opacity = outlineAlpha;
       mesh.material.transparent = true;
       mesh.material.depthWrite = false;
       mesh.material.needsUpdate = true;
@@ -2261,8 +2261,8 @@ async function applyHashState() {
       dandisetSubjectCounts = null;
       hiddenRegionIds = new Set();
       document.getElementById('region-toggles-overlay').classList.add('hidden');
-      document.getElementById('background-control-row').classList.add('hidden');
-      backgroundAlpha = 0;
+      document.getElementById('outline-control-row').classList.add('hidden');
+      outlineAlpha = 0;
       clearElectrodePoints();
       const prevEl = document.querySelector('.tree-node-content.selected');
       if (prevEl) prevEl.classList.remove('selected');

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <input type="range" id="region-alpha" min="0" max="1" step="0.05" value="1">
       </div>
       <div id="background-control-row" class="viewer-control-row hidden">
-        <label for="background-alpha">Background</label>
+        <label for="background-alpha">Atlas Outline</label>
         <input type="range" id="background-alpha" min="0" max="1" step="0.05" value="0.15">
       </div>
       <div id="electrode-control-row" class="viewer-control-row hidden">

--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
         <label for="region-alpha">Regions</label>
         <input type="range" id="region-alpha" min="0" max="1" step="0.05" value="1">
       </div>
+      <div id="background-control-row" class="viewer-control-row hidden">
+        <label for="background-alpha">Background</label>
+        <input type="range" id="background-alpha" min="0" max="1" step="0.05" value="0.15">
+      </div>
       <div id="electrode-control-row" class="viewer-control-row hidden">
         <label for="electrode-alpha">Electrodes</label>
         <input type="range" id="electrode-alpha" min="0" max="1" step="0.05" value="1">

--- a/index.html
+++ b/index.html
@@ -47,9 +47,9 @@
         <label for="region-alpha">Regions</label>
         <input type="range" id="region-alpha" min="0" max="1" step="0.05" value="1">
       </div>
-      <div id="background-control-row" class="viewer-control-row hidden">
-        <label for="background-alpha">Atlas Outline</label>
-        <input type="range" id="background-alpha" min="0" max="1" step="0.05" value="0.15">
+      <div id="outline-control-row" class="viewer-control-row hidden">
+        <label for="outline-alpha">Atlas Outline</label>
+        <input type="range" id="outline-alpha" min="0" max="1" step="0.05" value="0.15">
       </div>
       <div id="electrode-control-row" class="viewer-control-row hidden">
         <label for="electrode-alpha">Electrodes</label>

--- a/style.css
+++ b/style.css
@@ -1028,6 +1028,10 @@ body {
   accent-color: var(--accent);
 }
 
+#background-alpha {
+  accent-color: #888888;
+}
+
 #electrode-alpha {
   accent-color: #ff4466;
 }

--- a/style.css
+++ b/style.css
@@ -1028,7 +1028,7 @@ body {
   accent-color: var(--accent);
 }
 
-#background-alpha {
+#outline-alpha {
   accent-color: #888888;
 }
 


### PR DESCRIPTION
When you select a region, the viewer has two kinds of meshes: active meshes (the selected region and its descendants at full opacity) and the atlas outline (the root brain mesh shown as a gray silhouette). The outline helps the user understand where in the brain the active region sits.

Currently the CCF v3 viewer hides all non-active meshes completely when you select a region. This works because CCF has hundreds of data regions on DANDI, so the active selection plus its descendants usually fill enough of the brain to give you spatial orientation. However, in PR #10 (macaque atlas support) I was facing a different situation: we currently have only one dandiset with macaque data and it is restricted to the left motor cortex. Hiding everything left the selected region floating in empty space with no spatial reference. I added dimming on macaque atlases so non-selected meshes stay visible at low opacity instead of disappearing, but I did not want to modify the CCF code path in that PR.

The solution is an "Atlas Outline" slider that shows the brain outline as a translucent silhouette behind the active selection. This works the same way on all atlases regardless of how many regions they have: whether CCF with hundreds of data regions or a macaque atlas with just one, the outline always provides enough spatial context to orient yourself. The slider lets the user adjust how prominent the outline is, from fully transparent (0) to fully visible (1), so they can tune it to what works for their current task. It appears automatically when a region or dandiset is selected and defaults to a low value.

With some outline:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/2135764a-aa79-4d34-8d24-8855c7b513bf" />

Without outline:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/392cfb14-eaaa-4bc1-b58b-49083dd806a6" />
